### PR TITLE
댓글 CRUD 기능 구현

### DIFF
--- a/src/main/kotlin/com/example/bcm/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/controller/CommentController.kt
@@ -1,4 +1,59 @@
 package com.example.bcm.domain.comment.controller
 
-class CommentController {
+import com.example.bcm.domain.comment.dto.CommentResponse
+import com.example.bcm.domain.comment.dto.CreateCommentRequest
+import com.example.bcm.domain.comment.dto.UpdateCommentRequest
+import com.example.bcm.domain.comment.service.CommentService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+
+@RequestMapping("/posts/{postId}/comments")
+@RestController
+class CommentController (
+    private val commentService: CommentService
+){
+
+    @PostMapping
+    fun createComment(
+        @RequestParam postId: Long,
+        @RequestBody createCommentRequest: CreateCommentRequest
+    ): ResponseEntity<CommentResponse> {
+
+        val result = commentService.createComment(postId, createCommentRequest)
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(result)
+    }
+
+    @PutMapping("/{commentId}")
+    fun updateComment(
+        @PathVariable commentId: Long,
+        @RequestBody updateCommentRequest: UpdateCommentRequest
+    ): ResponseEntity<CommentResponse> {
+        val updateComment = commentService.updateComment(commentId, updateCommentRequest)
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(updateComment)
+    }
+
+    @DeleteMapping("/{commentId}")
+
+    fun deleteComment(
+        @PathVariable commentId: Long
+    ): ResponseEntity<String> {
+
+        commentService.deleteComment(commentId)
+        val deleteCommentSuccessMessage = "댓글이 성공적으로 삭제되었습니다."
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(deleteCommentSuccessMessage)
+
+    }
+
+
+
 }

--- a/src/main/kotlin/com/example/bcm/domain/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/dto/CommentResponse.kt
@@ -1,0 +1,18 @@
+package com.example.bcm.domain.comment.dto
+
+import com.example.bcm.domain.comment.model.Comment
+
+class CommentResponse (
+    var id: Long?,
+    var content: String
+) {
+    companion object {
+        fun toCommentResponse(comment: Comment
+        ): CommentResponse {
+            return CommentResponse(
+                id = comment.id,
+                content = comment.content
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/bcm/domain/comment/dto/CreateCommentRequest.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/dto/CreateCommentRequest.kt
@@ -1,0 +1,5 @@
+package com.example.bcm.domain.comment.dto
+
+data class CreateCommentRequest (
+    val content: String
+)

--- a/src/main/kotlin/com/example/bcm/domain/comment/dto/UpdateCommentRequest.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/dto/UpdateCommentRequest.kt
@@ -1,0 +1,5 @@
+package com.example.bcm.domain.comment.dto
+
+data class UpdateCommentRequest(
+    val content: String
+)

--- a/src/main/kotlin/com/example/bcm/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/repository/CommentRepository.kt
@@ -1,0 +1,7 @@
+package com.example.bcm.domain.comment.repository
+
+import com.example.bcm.domain.comment.model.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository: JpaRepository<Comment, Long> {
+}

--- a/src/main/kotlin/com/example/bcm/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/service/CommentService.kt
@@ -1,0 +1,17 @@
+package com.example.bcm.domain.comment.service
+
+import com.example.bcm.domain.comment.dto.CommentResponse
+import com.example.bcm.domain.comment.dto.CreateCommentRequest
+import com.example.bcm.domain.comment.dto.UpdateCommentRequest
+import com.example.bcm.domain.comment.model.Comment
+
+interface CommentService {
+
+    fun createComment (postId: Long, createCommentRequest: CreateCommentRequest): CommentResponse
+
+    fun updateComment (commentId: Long, request: UpdateCommentRequest): CommentResponse
+
+    fun deleteComment (commentId: Long)
+
+    fun getCommentById(commentId: Long): Comment
+}

--- a/src/main/kotlin/com/example/bcm/domain/comment/service/CommentServiceImpl.kt
+++ b/src/main/kotlin/com/example/bcm/domain/comment/service/CommentServiceImpl.kt
@@ -1,0 +1,65 @@
+package com.example.bcm.domain.comment.service
+
+import com.example.bcm.domain.comment.dto.CommentResponse
+import com.example.bcm.domain.comment.dto.CreateCommentRequest
+import com.example.bcm.domain.comment.dto.UpdateCommentRequest
+import com.example.bcm.domain.comment.model.Comment
+import com.example.bcm.domain.comment.repository.CommentRepository
+import com.example.bcm.domain.exception.ModelNotFoundException
+import com.example.bcm.domain.post.repository.PostRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+
+@Service
+class CommentServiceImpl (
+    private val commentRepository: CommentRepository,
+    private val postRepository: PostRepository
+): CommentService {
+
+    @Transactional
+    override fun createComment(postId: Long, createCommentRequest: CreateCommentRequest
+    ): CommentResponse {
+        val targetPost = postRepository.findByIdOrNull(postId)
+            ?: throw Exception("target post is not found")
+
+        val comment = Comment(
+            content = createCommentRequest.content,
+            nickname = "닉네임",
+            createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+        )
+
+        val result = commentRepository.save(comment)
+
+        return CommentResponse
+            .toCommentResponse(result)
+    }
+
+    @Transactional
+    override fun updateComment(commentId: Long, request: UpdateCommentRequest
+    ): CommentResponse {
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
+
+        comment.content = request.content
+
+        return CommentResponse.toCommentResponse(comment)
+    }
+
+    @Transactional
+    override fun deleteComment(commentId: Long) {
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
+
+        commentRepository.delete(comment)
+    }
+
+    override fun getCommentById(commentId: Long): Comment {
+        val comment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
+
+        return comment
+    }
+
+
+}

--- a/src/main/kotlin/com/example/bcm/domain/exception/ModelNotFoundException.kt
+++ b/src/main/kotlin/com/example/bcm/domain/exception/ModelNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.example.bcm.domain.exception
+
+data class ModelNotFoundException (val modelName: String, val id: Long?):
+        RuntimeException("Model ${modelName} not found with given id: ${id}") {
+}


### PR DESCRIPTION
1. Controller : 댓글의 CRUD에 대한 컨트롤러를 구현했습니다.
2. Repository : 댓글에 대한 리포지토리를 구현했습니다.
3. Service 및 ServiceImpl : 댓글에 대한 비즈니스 로직을 담당하는 서비스와 해당 서비스의 구현체를 구현했습니다.
4. DTO : 댓글 작성 및 수정 시 필요한 요청 클래스인 CreateCommentRequest와 UpdateCommentRequest를 구현했습니다.
5. ModelNotFoundException : 댓글을 찾을 수 없는 경우를 처리하기 위해 ModelNotFoundException 클래스를 생성해서 서비스에서 해당 예외를 적절히 처리할 수 있도록 로직을 추가했습니다.